### PR TITLE
:bug:  Correctly calculate total balance from transactions

### DIFF
--- a/app/src/main/java/digital/fischers/coinsaw/data/repository/CalculatedTransactionRepositoryImpl.kt
+++ b/app/src/main/java/digital/fischers/coinsaw/data/repository/CalculatedTransactionRepositoryImpl.kt
@@ -4,12 +4,11 @@ import digital.fischers.coinsaw.data.database.BillDao
 import digital.fischers.coinsaw.data.database.CalculatedTransaction
 import digital.fischers.coinsaw.data.database.CalculatedTransactionDao
 import digital.fischers.coinsaw.data.util.calculateTransactions
-import digital.fischers.coinsaw.domain.repository.BillRepository
 import digital.fischers.coinsaw.domain.repository.CalculatedTransactionRepository
+import digital.fischers.coinsaw.ui.utils.roundHalfUp
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.reduce
 import javax.inject.Inject
 
 class CalculatedTransactionRepositoryImpl @Inject constructor(
@@ -28,16 +27,16 @@ class CalculatedTransactionRepositoryImpl @Inject constructor(
         groupId: String,
         userId: String
     ): Flow<Double> {
-        return billDao.getAllBillsByGroupAndIsDeleted(groupId, isDeleted = false)
-            .map { bills ->
-                return@map bills.map { bill ->
-                    if (bill.userId == userId) {
-                        bill.amount - ((bill.amount * (bill.splittings.find { it.userId == userId }?.percent ?: 0.0)))
+        return getAllByGroupIdStream(groupId).map { transactions ->
+            transactions.filter { it.payerId == userId || it.payeeId == userId }
+                .fold(0.0) { acc, transaction ->
+                    if (transaction.payerId == userId) {
+                        acc - transaction.amount
                     } else {
-                        0.0 - bill.amount * (bill.splittings.find { it.userId == userId }?.percent ?: 0.0)
+                        acc + transaction.amount
                     }
-                }.sumOf { it }
-            }
+                }.roundHalfUp()
+        }
     }
 
     override suspend fun calculateForGroup(groupId: String) {

--- a/app/src/main/java/digital/fischers/coinsaw/ui/home/GroupUiState.kt
+++ b/app/src/main/java/digital/fischers/coinsaw/ui/home/GroupUiState.kt
@@ -8,7 +8,7 @@ data class HomeGroupUiState(
     val members: Number,
     val online: Boolean,
     val lastSync: Long?,
-    val balance: Double,
+    val balance: Double?,
     val currency: String,
     val lastTransactions: Flow<List<HomeTransactionUiState>>
 )

--- a/app/src/main/java/digital/fischers/coinsaw/ui/home/HomeScreen.kt
+++ b/app/src/main/java/digital/fischers/coinsaw/ui/home/HomeScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -58,7 +57,9 @@ fun HomeScreen(
             Column {
                 Text(
                     text = stringResource(id = R.string.screen_title_groups), style = TextStyle(
-                        fontSize = 24.sp, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.neutral
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.neutral
                     )
                 )
             }
@@ -116,7 +117,8 @@ fun HomeScreen(
                     item {
                         Spacer(modifier = Modifier.height(16.dp))
                         ActionButtonRow(
-                            onGroupAddClicked = onGroupAddClicked, onGroupJoinClicked = onGroupJoinClicked
+                            onGroupAddClicked = onGroupAddClicked,
+                            onGroupJoinClicked = onGroupJoinClicked
                         )
                         Spacer(modifier = Modifier.height(32.dp))
                     }
@@ -192,12 +194,13 @@ fun ActionButton(
 fun GroupCard(
     groupUiState: HomeGroupUiState, onClick: (String) -> Unit
 ) {
-    Column(modifier = Modifier
-        .clip(MaterialTheme.shapes.medium)
-        .clickable { onClick(groupUiState.id) }
-        .fillMaxWidth()
-        .background(MaterialTheme.colorScheme.surface)
-        .padding(16.dp)) {
+    Column(
+        modifier = Modifier
+            .clip(MaterialTheme.shapes.medium)
+            .clickable { onClick(groupUiState.id) }
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -206,7 +209,9 @@ fun GroupCard(
             Column {
                 Text(
                     text = groupUiState.name, style = TextStyle(
-                        fontSize = 20.sp, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.neutral
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.neutral
                     )
                 )
                 Spacer(modifier = Modifier.height(6.dp))
@@ -228,29 +233,31 @@ fun GroupCard(
                     )
                 )
             }
-            Box(
-                modifier = Modifier
-                    .clip(MaterialTheme.shapes.small)
-                    .background(
-                        when {
-                            groupUiState.balance > 0.009 -> MaterialTheme.colorScheme.secondaryContainer
-                            groupUiState.balance < 0.000 -> MaterialTheme.colorScheme.error
-                            else -> MaterialTheme.colorScheme.secondary
-                        }
-                    )
-                    .padding(8.dp)
-            ) {
-                Text(
-                    text = "${
-                        String.format(
-                            Locale.getDefault(), "%.2f", groupUiState.balance
+            if (groupUiState.balance != null) {
+                Box(
+                    modifier = Modifier
+                        .clip(MaterialTheme.shapes.small)
+                        .background(
+                            when {
+                                groupUiState.balance > 0.009 -> MaterialTheme.colorScheme.secondaryContainer
+                                groupUiState.balance < 0.000 -> MaterialTheme.colorScheme.error
+                                else -> MaterialTheme.colorScheme.secondary
+                            }
                         )
-                    } ${groupUiState.currency}", style = TextStyle(
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.surface
+                        .padding(8.dp)
+                ) {
+                    Text(
+                        text = "${
+                            String.format(
+                                Locale.getDefault(), "%.2f", groupUiState.balance
+                            )
+                        } ${groupUiState.currency}", style = TextStyle(
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.surface
+                        )
                     )
-                )
+                }
             }
         }
     }

--- a/app/src/main/java/digital/fischers/coinsaw/ui/viewModels/HomeViewModel.kt
+++ b/app/src/main/java/digital/fischers/coinsaw/ui/viewModels/HomeViewModel.kt
@@ -32,10 +32,11 @@ class HomeViewModel @Inject constructor(
             val members = userRepository.getAllUsersByGroupIdStream(group.id).firstOrNull()?.count()
                 ?: 0
 
-            val balance = calculatedTransactionRepository.getTotalBalanceByGroupIdAndUserId(
-                group.id,
-                me?.id ?: ""
-            ).firstOrNull() ?: 0.0
+            val balance =
+                if (me != null) calculatedTransactionRepository.getTotalBalanceByGroupIdAndUserId(
+                    group.id,
+                    me.id
+                ).firstOrNull() ?: 0.0 else null
 
             val lastTransactions = billRepository.getBillsByGroupAndIsDeletedStream(
                 group.id,


### PR DESCRIPTION
The total balance for a user within a group is now correctly calculated by summing up the pre-calculated transactions.

This change also handles cases where a local user might not be chosen (`me` is null)